### PR TITLE
Add enable_set_attributes flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Module usage:
 |------|-------------|:----:|:-----:|:-----:|
 | content_based_deduplication | Enables content-based deduplication for FIFO queues | string | `false` | no |
 | delay_seconds | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes) | string | `0` | no |
+| enable_set_attributes | Should the created iam user be permitted to set queue attributes | string | `true` | no |
 | environment | The environment the SQS is running in i.e. dev, prod etc | string | - | yes |
 | fifo_queue | Boolean designating a FIFO queue | string | `false` | no |
 | iam_user_policy_name | The policy name of attached to the user | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -370,7 +370,7 @@ data "aws_iam_policy_document" "sqs_policy_document" {
       aws_sqs_queue.queue[0].arn,
     ]
 
-    actions = [
+    actions = concat([
       "sqs:AddPermission",
       "sqs:ChangeMessageVisibility*",
       "sqs:DeleteMessage*",
@@ -380,8 +380,7 @@ data "aws_iam_policy_document" "sqs_policy_document" {
       "sqs:ReceiveMessage",
       "sqs:RemovePermission",
       "sqs:Send*",
-      "sqs:SetQueueAttributes",
-    ]
+    ], var.enable_set_attributes ? ["sqs:SetQueueAttributes"] : [])
   }
 }
 
@@ -397,7 +396,7 @@ data "aws_iam_policy_document" "sqs_with_kms_policy_document" {
       aws_sqs_queue.queue_with_kms[0].arn,
     ]
 
-    actions = [
+    actions = concat([
       "sqs:AddPermission",
       "sqs:ChangeMessageVisibility*",
       "sqs:DeleteMessage*",
@@ -407,8 +406,7 @@ data "aws_iam_policy_document" "sqs_with_kms_policy_document" {
       "sqs:ReceiveMessage",
       "sqs:RemovePermission",
       "sqs:Send*",
-      "sqs:SetQueueAttributes",
-    ]
+    ], var.enable_set_attributes ? ["sqs:SetQueueAttributes"] : [])
   }
 
   statement {
@@ -447,7 +445,7 @@ data "aws_iam_policy_document" "sqs_with_redrive_policy_document" {
       aws_sqs_queue.queue_with_redrive[0].arn,
     ]
 
-    actions = [
+    actions = concat([
       "sqs:AddPermission",
       "sqs:ChangeMessageVisibility*",
       "sqs:DeleteMessage*",
@@ -457,8 +455,7 @@ data "aws_iam_policy_document" "sqs_with_redrive_policy_document" {
       "sqs:ReceiveMessage",
       "sqs:RemovePermission",
       "sqs:Send*",
-      "sqs:SetQueueAttributes",
-    ]
+    ], var.enable_set_attributes ? ["sqs:SetQueueAttributes"] : [])
   }
 }
 
@@ -475,7 +472,7 @@ data "aws_iam_policy_document" "sqs_with_kms_and_redrive_policy_document" {
       aws_sqs_queue.queue_with_kms_and_redrive[0].arn,
     ]
 
-    actions = [
+    actions = concat([
       "sqs:AddPermission",
       "sqs:ChangeMessageVisibility*",
       "sqs:DeleteMessage*",
@@ -485,8 +482,7 @@ data "aws_iam_policy_document" "sqs_with_kms_and_redrive_policy_document" {
       "sqs:ReceiveMessage",
       "sqs:RemovePermission",
       "sqs:Send*",
-      "sqs:SetQueueAttributes",
-    ]
+    ], var.enable_set_attributes ? ["sqs:SetQueueAttributes"] : [])
   }
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,8 @@ variable "kms_key_policy" {
   description = "KMS key policy (uses a default policy if omitted)"
   default     = ""
 }
+
+variable "enable_set_attributes" {
+  description = "Should the created iam user be permitted to set queue attributes"
+  default     = true
+}


### PR DESCRIPTION
Adds a flag allowing users to prevent setting of queue attributes via the created iam user.