### PR TITLE
ACPENG-3033 widen AWS provider constraint to >= 3.0, < 5.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70"
+      version = ">= 3.0, < 5.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-3033